### PR TITLE
Fix Markdown formatting

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -149,8 +149,8 @@ inputs:
     opts:	    
       category: "Deprecated"
       title: "[DEPRECATED] App bundle output pattern"	
-      summary: "Pattern to find built AAB artifacts relative to $BITRISE_SOURCE_DIR Deprecated, use `android_output_pattern` instead."
-      description: "Pattern to find built AAB artifacts relative to $BITRISE_SOURCE_DIR"
+      summary: "Pattern to find built AAB artifacts relative to `$BITRISE_SOURCE_DIR`. Deprecated, use `android_output_pattern` instead."
+      description: "Pattern to find built AAB artifacts relative to `$BITRISE_SOURCE_DIR`"
 
 
 outputs:


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

The underscore in BITRISE_SOURCE_DIR was interpreted as italics formatting

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
