### PR TITLE
Migrate to Unified CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,181 +1,43 @@
-format_version: 8
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-  - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-flutter-ios-android.git
   - ORIGIN_SOURCE_DIR: $BITRISE_SOURCE_DIR
 
-  
 workflows:
-  ci:
-    before_run:
-    - audit-this-step
-    steps:
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
-    - flutter-installer:
-    after_run:
-    - test_cache
-    - test_ios
-    - test_android_apk
-    - test_android_aab
-    - test_android_split_apk
-    - test_both
-
-  ci-android-only:
-    before_run:
-    - audit-this-step
-    steps:
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
-    - flutter-installer:
-    after_run:
-    - test_android_apk
-    - test_android_aab
-
-  test_ios:
-    before_run:
-    - _clear_workdir
+  sample:
+    envs:
+    - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-flutter-ios-android.git
     steps:
     - script:
-        title: Clone sample app
         inputs:
-        - content: git clone $SAMPLE_APP_URL .
+        - content: |-
+            #!/bin/env bash
+            set -ex
+            rm -rf ./_tmp
+    - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
+        inputs:
+        - repository_url: $SAMPLE_APP_URL
+        - branch: master
+        - clone_into_dir: ./_tmp
     - path::./:
-        inputs: 
+        inputs:
+        - project_location: ./_tmp
         - is_debug_mode: "true"
-        - platform: ios
-
-  test_android_apk:
-    before_run:
-    - _clear_workdir
-    steps:
-    - script:
-        title: Clone sample app
-        inputs:
-        - content: git clone $SAMPLE_APP_URL .
-    - path::./:
-        inputs: 
-        - is_debug_mode: "true"
-        - platform: android
-  test_android_split_apk:
-    before_run:
-    - _clear_workdir
-    steps:
-    - script:
-        title: Clone sample app
-        inputs:
-        - content: git clone $SAMPLE_APP_URL .
-    - path::./:
-        inputs: 
-        - android_additional_params: --release --split-per-abi
-        - is_debug_mode: "true"
-        - platform: android
-
-  test_android_aab:
-    before_run:
-      - _clear_workdir
-    steps:
-      - script:
-          title: Clone sample app
-          inputs:
-            - content: git clone $SAMPLE_APP_URL .
-      - path::./:
-          inputs:
-            - is_debug_mode: "true"
-            - platform: android
-            - android_output_type: appbundle
-
-  test_both:
-    before_run:
-    - _clear_workdir
-    steps:
-    - script:
-        title: Clone sample app
-        inputs:
-        - content: git clone $SAMPLE_APP_URL .
-    - path::./:
-        inputs:
-        - is_debug_mode: "true" 
         - platform: both
+        - android_output_type: appbundle
 
-
-  test_cache:
-    envs:
-    - BITRISE_CACHE_API_URL: file:///$ORIGIN_SOURCE_DIR/_cache.tar.gz
-    before_run:
-    - _clear_workdir
+  check:
     steps:
-    - script:
-        title: Clone sample app
-        inputs:
-          - content: |-
-              git clone $SAMPLE_APP_URL .
-    - script:
-        input:
-        - content: |-
-            rm -rf $HOME/.pub-cache
-    - cache-pull:
-        run_if: true
-    - path::./:
-        inputs:
-        - is_debug_mode: "true" 
-        - platform: android
-        - android_output_type: apk
-        - android_additional_params: ''
-        - cache_level: all
-    - cache-push:
-        run_if: true
-    - script:
-        input:
-        - content: |-
-            rm -rf $HOME/.pub-cache
-    - cache-pull:
-        run_if: true
-    - path::./:
-        inputs:
-        - is_debug_mode: "true" 
-        - platform: android
-        - android_output_type: apk
-        - android_additional_params: ''
-        - cache_level: all
-          
+    - git::https://github.com/bitrise-steplib/steps-check.git:
 
-  _clear_workdir:
-    envs:
+  e2e:
     steps:
-    - script:
+    - git::https://github.com/bitrise-steplib/steps-check.git:
         inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            cd ${ORIGIN_SOURCE_DIR}
-            rm -rf "./_tmp"
-            mkdir "_tmp"
-    - change-workdir:
-        title: Switch working dir to test / _tmp dir
-        description: |-
-          To prevent step testing issues, like referencing relative
-          files with just './some-file' in the step's code, which would
-          work for testing the step from this directory directly
-          but would break if the step is included in another `bitrise.yml`.
-        run_if: true
-        inputs:
-        - path: ${ORIGIN_SOURCE_DIR}/_tmp
-        - is_create_path: true
+        - workflow: e2e
 
-  # ----------------------------------------------------------------
-  # --- workflows to Share this step into a Step Library
-  audit-this-step:
+  generate-readme:
     steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            stepman audit --step-yml ./step.yml
+    - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,0 +1,142 @@
+format_version: "11"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+app:
+  envs:
+  - SAMPLE_APP_URL: https://github.com/bitrise-samples/sample-apps-flutter-ios-android.git
+  - ORIGIN_SOURCE_DIR: $BITRISE_SOURCE_DIR
+
+workflows:
+  test_ios:
+    before_run:
+    - _clear_workdir
+    steps:
+    - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
+        inputs:
+        - repository_url: $SAMPLE_APP_URL
+        - clone_into_dir: ./
+        - branch: master
+    - path::./:
+        inputs:
+        - is_debug_mode: "true"
+        - platform: ios
+
+  test_android_apk:
+    before_run:
+    - _clear_workdir
+    steps:
+    - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
+        inputs:
+        - repository_url: $SAMPLE_APP_URL
+        - clone_into_dir: ./
+        - branch: master
+    - path::./:
+        inputs:
+        - is_debug_mode: "true"
+        - platform: android
+
+  test_android_split_apk:
+    before_run:
+    - _clear_workdir
+    steps:
+    - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
+        inputs:
+        - repository_url: $SAMPLE_APP_URL
+        - clone_into_dir: ./
+        - branch: master
+    - path::./:
+        inputs:
+        - android_additional_params: --release --split-per-abi
+        - is_debug_mode: "true"
+        - platform: android
+
+  test_android_aab:
+    before_run:
+    - _clear_workdir
+    steps:
+    - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
+        inputs:
+        - repository_url: $SAMPLE_APP_URL
+        - clone_into_dir: ./
+        - branch: master
+    - path::./:
+        inputs:
+        - is_debug_mode: "true"
+        - platform: android
+        - android_output_type: appbundle
+
+  test_both:
+    before_run:
+    - _clear_workdir
+    steps:
+    - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
+        inputs:
+        - repository_url: $SAMPLE_APP_URL
+        - clone_into_dir: ./
+        - branch: master
+    - path::./:
+        inputs:
+        - is_debug_mode: "true"
+        - platform: both
+
+  test_cache:
+    envs:
+    - BITRISE_CACHE_API_URL: file:///$ORIGIN_SOURCE_DIR/_cache.tar.gz
+    before_run:
+    - _clear_workdir
+    steps:
+    - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
+        inputs:
+        - repository_url: $SAMPLE_APP_URL
+        - clone_into_dir: ./
+        - branch: master
+    - script:
+        inputs:
+        - content: |-
+            rm -rf $HOME/.pub-cache
+    - cache-pull:
+        run_if: true
+    - path::./:
+        inputs:
+        - is_debug_mode: "true"
+        - platform: android
+        - android_output_type: apk
+        - android_additional_params: ''
+        - cache_level: all
+    - cache-push:
+        run_if: true
+    - script:
+        inputs:
+        - content: |-
+            rm -rf $HOME/.pub-cache
+    - cache-pull:
+        run_if: true
+    - path::./:
+        inputs:
+        - is_debug_mode: "true"
+        - platform: android
+        - android_output_type: apk
+        - android_additional_params: ''
+        - cache_level: all
+
+  _clear_workdir:
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            cd ${ORIGIN_SOURCE_DIR}
+            rm -rf "./_tmp"
+            mkdir "_tmp"
+    - change-workdir:
+        title: Switch working dir to test / _tmp dir
+        description: |-
+          To prevent step testing issues, like referencing relative
+          files with just './some-file' in the step's code, which would
+          work for testing the step from this directory directly
+          but would break if the step is included in another `bitrise.yml`.
+        run_if: true
+        inputs:
+        - path: ${ORIGIN_SOURCE_DIR}/_tmp
+        - is_create_path: true

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -9,7 +9,7 @@ app:
 workflows:
   test_ios:
     before_run:
-    - _clear_workdir
+    - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
@@ -23,7 +23,7 @@ workflows:
 
   test_android_apk:
     before_run:
-    - _clear_workdir
+    - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
@@ -37,7 +37,7 @@ workflows:
 
   test_android_split_apk:
     before_run:
-    - _clear_workdir
+    - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
@@ -52,7 +52,7 @@ workflows:
 
   test_android_aab:
     before_run:
-    - _clear_workdir
+    - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
@@ -67,7 +67,7 @@ workflows:
 
   test_both:
     before_run:
-    - _clear_workdir
+    - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
@@ -83,7 +83,7 @@ workflows:
     envs:
     - BITRISE_CACHE_API_URL: file:///$ORIGIN_SOURCE_DIR/_cache.tar.gz
     before_run:
-    - _clear_workdir
+    - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
@@ -119,7 +119,7 @@ workflows:
         - android_additional_params: ''
         - cache_level: all
 
-  _clear_workdir:
+  _setup_test:
     steps:
     - script:
         inputs:
@@ -140,3 +140,9 @@ workflows:
         inputs:
         - path: ${ORIGIN_SOURCE_DIR}/_tmp
         - is_create_path: true
+    - android-sdk-update:
+        inputs:
+        - platform_tools: stable
+        - build_tools: 28.0.3
+        - sdk_version: '28'
+        - tools: 'on'

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -9,6 +9,28 @@ app:
 workflows:
   test_ios:
     before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eo pipefail
+
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode >= 11, skipping..."
+              exit 0
+            fi
+
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
+        inputs:
+        - workflow_id: utility_test_ios
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_ios:
+    before_run:
     - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
@@ -23,6 +45,28 @@ workflows:
 
   test_android_apk:
     before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eo pipefail
+
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode >= 11, skipping..."
+              exit 0
+            fi
+
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
+        inputs:
+        - workflow_id: utility_test_android_apk
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_android_apk:
+    before_run:
     - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
@@ -36,6 +80,28 @@ workflows:
         - platform: android
 
   test_android_split_apk:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eo pipefail
+
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode >= 11, skipping..."
+              exit 0
+            fi
+
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
+        inputs:
+        - workflow_id: utility_test_android_split_apk
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_android_split_apk:
     before_run:
     - _setup_test
     steps:
@@ -52,6 +118,28 @@ workflows:
 
   test_android_aab:
     before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eo pipefail
+
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode >= 11, skipping..."
+              exit 0
+            fi
+
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
+        inputs:
+        - workflow_id: utility_test_android_aab
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_android_aab:
+    before_run:
     - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
@@ -67,6 +155,28 @@ workflows:
 
   test_both:
     before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eo pipefail
+
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode >= 11, skipping..."
+              exit 0
+            fi
+
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
+        inputs:
+        - workflow_id: utility_test_both
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_both:
+    before_run:
     - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
@@ -80,6 +190,28 @@ workflows:
         - platform: both
 
   test_cache:
+    before_run:
+    - _expose_xcode_version
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eo pipefail
+
+            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+              echo "This test case requires Xcode >= 11, skipping..."
+              exit 0
+            fi
+
+            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
+    - bitrise-run:
+        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
+        inputs:
+        - workflow_id: utility_test_cache
+        - bitrise_config_path: ./e2e/bitrise.yml
+
+  utility_test_cache:
     envs:
     - BITRISE_CACHE_API_URL: file:///$ORIGIN_SOURCE_DIR/_cache.tar.gz
     before_run:
@@ -118,6 +250,28 @@ workflows:
         - android_output_type: apk
         - android_additional_params: ''
         - cache_level: all
+
+  _expose_xcode_version:
+    steps:
+    - script:
+        title: Expose Xcode major version
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -eo pipefail
+            if [[ ! -z "$XCODE_MAJOR_VERSION" ]]; then
+              echo "Xcode major version already exposed: $XCODE_MAJOR_VERSION"
+              exit 0
+            fi
+            version=`xcodebuild -version`
+            regex="Xcode ([0-9]*)."
+            if [[ ! $version =~ $regex ]]; then
+              echo "Failed to determine Xcode major version"
+              exit 1
+            fi
+            xcode_major_version=${BASH_REMATCH[1]}
+            echo "Xcode major version: $xcode_major_version"
+            envman add --key XCODE_MAJOR_VERSION --value $xcode_major_version
 
   _setup_test:
     steps:


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context
* PRs from forked repositories require explicit approval to run checks on Bitrise.
* This PR is currently failing: https://github.com/bitrise-steplib/bitrise-step-flutter-build/pull/33. This is because its primary workflow is trying to start another workflow that also needs explicit approval. However, in this case it's unable to obtain the build slug of the started build, which fails the Wait for Build step.
* We can solve this problem by migrating this step to the Unified CI, which would be done anyway at some point. 

### Changes
**Migrate this Step to Unified CI.**
* Added `e2e/bitrise.yml` and migrated existing E2E tests there.
* Replaced `bitrise.yml` with the sample Unified CI one.
* Both changes are based on this guide: https://bitrise.atlassian.net/wiki/spaces/~260708089/pages/1547960477/Step+migration+to+unified-ci.
* Note: the step also has workflows stored on Bitrise, but those didn't need to be migrated luckily, as most of their responsibilities are already taken care of by the Unified CI (release, running tests on multiple stacks, etc.).

<details>
  <summary>bitrise.yml stored on Bitrise</summary>
  
  ```yml
---
format_version: '6'
default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
project_type: other
app:
  envs:
  - GO15VENDOREXPERIMENT: '1'
  - SRC_DIR_IN_GOPATH: "$GOPATH/src/github.com/bitrise-steplib/bitrise-step-flutter-build"
trigger_map:
- push_branch: master
  workflow: primary
- pull_request_source_branch: "*"
  workflow: primary
  pull_request_target_branch: master
- tag: "*.*.*"
  workflow: release
workflows:
  primary:
    steps:
    - build-router-start@0:
        inputs:
        - access_token: "$BITRISE_ACCESS_TOKEN"
        - workflows: primary-ubuntu-stack
    - change-workdir:
        inputs:
        - path: "${SRC_DIR_IN_GOPATH}"
    - git-clone: {}
    - android-sdk-update@1:
        inputs:
        - platform_tools: stable
        - build_tools: 28.0.3
        - sdk_version: '28'
        - tools: 'on'
    - certificate-and-profile-installer@1.10.1: {}
    - script:
        inputs:
        - content: bitrise run ci
    - deploy-to-bitrise-io@1.3.18:
        inputs:
        - notify_user_groups: none
    - build-router-wait@0:
        inputs:
        - access_token: "$BITRISE_ACCESS_TOKEN"
  primary-ubuntu-stack:
    steps:
    - change-workdir:
        inputs:
        - path: "${SRC_DIR_IN_GOPATH}"
    - git-clone: {}
    - script:
        inputs:
        - content: bitrise run ci-android-only
    - deploy-to-bitrise-io@1.3.18:
        inputs:
        - notify_user_groups: none
    meta:
      bitrise.io:
        stack: linux-docker-android
  release:
    steps:
    - trigger-bitrise-workflow@0.0.4:
        inputs:
        - api_token: "$CONTROL_CENTER_TRIGGER_KEY"
        - workflow_id: step-release
        - exported_environment_variable_names: STEP_ID_IN_STEPLIB|GIT_REPOSITORY_URL
        - app_slug: "$CONTROL_CENTER_APP_SLUG"
  test-primary-lts-20:
    steps:
    - change-workdir:
        inputs:
        - path: "${SRC_DIR_IN_GOPATH}"
    - git-clone: {}
    - script:
        inputs:
        - content: bitrise run ci-android-only
    - deploy-to-bitrise-io@1.3.18: {}
    meta:
      bitrise.io:
        stack: linux-docker-android-20.04
meta:
  bitrise.io:
    machine_type_id: standard

  ```
</details>