### PR TITLE
Run iOS tests only on non-Ubuntu stacks

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -17,7 +17,7 @@ workflows:
             #!/bin/bash
             set -eo pipefail
 
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+            if [[ $XCODE_AVAILABLE == false ]] || [[ $XCODE_MAJOR_VERSION -lt 11 ]]; then
               echo "This test case requires Xcode >= 11, skipping..."
               exit 0
             fi
@@ -45,28 +45,6 @@ workflows:
 
   test_android_apk:
     before_run:
-    - _expose_xcode_version
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eo pipefail
-
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode >= 11, skipping..."
-              exit 0
-            fi
-
-            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-    - bitrise-run:
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
-        inputs:
-        - workflow_id: utility_test_android_apk
-        - bitrise_config_path: ./e2e/bitrise.yml
-
-  utility_test_android_apk:
-    before_run:
     - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
@@ -80,28 +58,6 @@ workflows:
         - platform: android
 
   test_android_split_apk:
-    before_run:
-    - _expose_xcode_version
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eo pipefail
-
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode >= 11, skipping..."
-              exit 0
-            fi
-
-            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-    - bitrise-run:
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
-        inputs:
-        - workflow_id: utility_test_android_split_apk
-        - bitrise_config_path: ./e2e/bitrise.yml
-
-  utility_test_android_split_apk:
     before_run:
     - _setup_test
     steps:
@@ -117,28 +73,6 @@ workflows:
         - platform: android
 
   test_android_aab:
-    before_run:
-    - _expose_xcode_version
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eo pipefail
-
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode >= 11, skipping..."
-              exit 0
-            fi
-
-            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-    - bitrise-run:
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
-        inputs:
-        - workflow_id: utility_test_android_aab
-        - bitrise_config_path: ./e2e/bitrise.yml
-
-  utility_test_android_aab:
     before_run:
     - _setup_test
     steps:
@@ -163,7 +97,7 @@ workflows:
             #!/bin/bash
             set -eo pipefail
 
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+            if [[ $XCODE_AVAILABLE == false ]] || [[ $XCODE_MAJOR_VERSION -lt 11 ]]; then
               echo "This test case requires Xcode >= 11, skipping..."
               exit 0
             fi
@@ -190,28 +124,6 @@ workflows:
         - platform: both
 
   test_cache:
-    before_run:
-    - _expose_xcode_version
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eo pipefail
-
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode >= 11, skipping..."
-              exit 0
-            fi
-
-            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-    - bitrise-run:
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
-        inputs:
-        - workflow_id: utility_test_cache
-        - bitrise_config_path: ./e2e/bitrise.yml
-
-  utility_test_cache:
     envs:
     - BITRISE_CACHE_API_URL: file:///$ORIGIN_SOURCE_DIR/_cache.tar.gz
     before_run:
@@ -253,28 +165,6 @@ workflows:
 
   test_additional_build_params_android:
     before_run:
-    - _expose_xcode_version
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -eo pipefail
-
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
-              echo "This test case requires Xcode >= 11, skipping..."
-              exit 0
-            fi
-
-            envman add --key XCODE_MAJOR_VERSION_AT_LEAST_11 --value "true"
-    - bitrise-run:
-        run_if: '{{enveq "XCODE_MAJOR_VERSION_AT_LEAST_11" "true"}}'
-        inputs:
-        - workflow_id: utility_test_additional_build_params_android
-        - bitrise_config_path: ./e2e/bitrise.yml
-
-  utility_test_additional_build_params_android:
-    before_run:
     - _setup_test
     steps:
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
@@ -307,7 +197,7 @@ workflows:
             #!/bin/bash
             set -eo pipefail
 
-            if [[ ${XCODE_MAJOR_VERSION} -lt 11 ]]; then
+            if [[ $XCODE_AVAILABLE == false ]] || [[ $XCODE_MAJOR_VERSION -lt 11 ]]; then
               echo "This test case requires Xcode >= 11, skipping..."
               exit 0
             fi
@@ -352,9 +242,14 @@ workflows:
         - content: |-
             #!/bin/bash
             set -eo pipefail
+            envman add --key XCODE_AVAILABLE --value false
             if [[ ! -z "$XCODE_MAJOR_VERSION" ]]; then
               echo "Xcode major version already exposed: $XCODE_MAJOR_VERSION"
               exit 0
+            fi
+            if ! command -v xcodebuild &> /dev/null; then
+                echo "Xcode is not available."
+                exit 0
             fi
             version=`xcodebuild -version`
             regex="Xcode ([0-9]*)."
@@ -364,6 +259,7 @@ workflows:
             fi
             xcode_major_version=${BASH_REMATCH[1]}
             echo "Xcode major version: $xcode_major_version"
+            envman add --key XCODE_AVAILABLE --value true
             envman add --key XCODE_MAJOR_VERSION --value $xcode_major_version
 
   _setup_test:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -289,3 +289,4 @@ workflows:
         - build_tools: 28.0.3
         - sdk_version: '28'
         - tools: 'on'
+    - flutter-installer:


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context
* **Unified CI now runs E2E tests on Ubuntu as well if `flutter` is specified in `project_type_tags`.**

### Changes
* Run E2E tests that build an iOS app only if Xcode is available (only on non-Ubuntu stacks).
* Remove unnecessary check for Xcode version when only an Android app is built.
* Install Flutter before running tests (as it might not be the latest stable AND it's not pre-installed on Ubuntu).